### PR TITLE
Add vitess dialect

### DIFF
--- a/dialect.go
+++ b/dialect.go
@@ -26,6 +26,7 @@ var driverDialect = map[string]dialect{
 	"*gosnowflake.SnowflakeDriver": postgresDialect{}, // github.com/snowflakedb/gosnowflake
 	"*mysql.MySQLDriver":           mysqlDialect{},    // github.com/go-sql-driver/mysql
 	"*godrv.Driver":                mysqlDialect{},    // github.com/ziutek/mymysql
+	"*vitessdriver.drv":            mysqlDialect{},    // github.com/vitessio/vitess
 	"*mssql.Driver":                mssqlDialect{},    // github.com/denisenkom/go-mssqldb
 	"*mssql.MssqlDriver":           mssqlDialect{},    // github.com/denisenkom/go-mssqldb
 	"*freetds.MssqlDriver":         mssqlDialect{},    // github.com/minus5/gofreetds

--- a/dialect.go
+++ b/dialect.go
@@ -26,7 +26,7 @@ var driverDialect = map[string]dialect{
 	"*gosnowflake.SnowflakeDriver": postgresDialect{}, // github.com/snowflakedb/gosnowflake
 	"*mysql.MySQLDriver":           mysqlDialect{},    // github.com/go-sql-driver/mysql
 	"*godrv.Driver":                mysqlDialect{},    // github.com/ziutek/mymysql
-	"*vitessdriver.drv":            mysqlDialect{},    // github.com/vitessio/vitess
+	"vitessdriver.drv":             mysqlDialect{},    // github.com/vitessio/vitess
 	"*mssql.Driver":                mssqlDialect{},    // github.com/denisenkom/go-mssqldb
 	"*mssql.MssqlDriver":           mssqlDialect{},    // github.com/denisenkom/go-mssqldb
 	"*freetds.MssqlDriver":         mssqlDialect{},    // github.com/minus5/gofreetds


### PR DESCRIPTION
I attempted to get schema information out of Vitess schema information using this library. Vitess is a sharding system from Youtube written in Go.
Since Vitess is MySQL under the hood and supports the MySQL dialect I figured it would work. However the error I got suggested this library did not recognize the vitess driver. Understandable. So I simply added it to the driverDialect map with a reference to the mysql dialect and it worked fine after that.

Would love to contribute this small change back since it might help someone else. One could imagine adding a whole dialect for getting more vitess specific information also, but that might be another day.

For reference: https://vitess.io/